### PR TITLE
improved integration of PROPKA into Python scripts

### DIFF
--- a/propka/lib.py
+++ b/propka/lib.py
@@ -107,7 +107,7 @@ def make_combination(combis, interaction):
 
 
 
-def loadOptions():
+def loadOptions(*args):
     """
     load the arguments parser with options
     """
@@ -166,7 +166,11 @@ def loadOptions():
 
 
     # parsing and returning options and arguments
-    options, args = parser.parse_args()
+    if len(args) == 0:
+        # command line
+        options, args = parser.parse_args()
+    else:
+        options, args = parser.parse_args(list(args))
 
     # adding specified filenames to arguments
     if options.filenames:

--- a/propka/run.py
+++ b/propka/run.py
@@ -13,3 +13,21 @@ def main():
         my_molecule = propka.molecular_container.Molecular_container(pdbfile, options)
         my_molecule.calculate_pka()
         my_molecule.write_pka()
+
+def single(pdbfile, optargs=None):
+    """Run a single PROPKA calculation using *pdbfile* as input.
+
+    Commandline options can be passed as a **list** in *optargs*.
+
+    .. rubric:: Example
+
+    ::
+       single("protein.pdb", optargs=["--mutation=N25R/N181D", "-v", "--pH=7.2"])
+    """
+    optargs = optargs if optargs is not None else []
+    options, ignored_pdbfiles = propka.lib.loadOptions(*optargs)
+
+    my_molecule = propka.molecular_container.Molecular_container(pdbfile, options)
+    my_molecule.calculate_pka()
+    my_molecule.write_pka()
+    return my_molecule


### PR DESCRIPTION
The two commits add the capability to run a PROPKA calculation from another Python script. At the moment the support is rudimentary in that one simply supplies the commandline options as a list to the new function `run.single()`:

``` python
import propka.run
mol = propka.run.single("protein.pdb", optargs=["--mutation=N25R/N181D", "-v", "--pH=7.2"])
```

Additionally, small changes were made so that instead of files, any kind of Python streams can be used. This improves the way PROPKA can be integrated into workflows whereby other code writes PDB structures to a StringIO object instead of to disk, and PROPKA reads its input from this memory buffer.
