### PR TITLE
increase sphinx to >= 3.1 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 numpy
-sphinx
+sphinx>=3.1
 sphinx_rtd_theme


### PR DESCRIPTION
- fix #72
- our sphinx docs need >= 3.1 because they use autosummary with :recursive: