### PR TITLE
Include explicit link to web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ PROPKA 3 requires Python 3.6 or higher.  Additional requirements are specified i
 
 ## Installation
 
+PROPKA can be installed on your own computer (as described below) or run from a [web interface](http://server.poissonboltzmann.org) (please [register](http://eepurl.com/by4eQr) first).
+
 ### PIP-based installation
 
 The easiest way to install PROPKA is via the [PyPI archive](https://pypi.org/project/PROPKA/) with the command


### PR DESCRIPTION
http://propka.org currently redirects to http://server.poissonboltzmann.org.  However, the http://server.poissonboltzmann.org site does not include any specific documentation for PROPKA.  I'd like @jhjensen2 to update the DNS record for http://propka.org to redirect to https://github.com/jensengroup/propka or https://propka.readthedocs.io/.  However, before he does that, it would be good to make sure that users can still find a link to run PROPKA via http://server.poissonboltzmann.org.  This edit provides that link.