### PR TITLE
fixes run's single method

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,3 +73,6 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Enable intersphinx mapping
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/propka/input.py
+++ b/propka/input.py
@@ -49,7 +49,7 @@ def read_molecule_file(filename: str, mol_container, stream=None):
         updated :class:`~propka.molecular_container.MolecularContainer` object.
 
     Raises:
-        ValuError if invalid input given
+        ValuError: if invalid input given
 
     Examples:
         There are two main cases for using ``read_molecule_file``. The first

--- a/propka/input.py
+++ b/propka/input.py
@@ -7,7 +7,6 @@ Input routines.
 from pathlib import Path
 from pkg_resources import resource_filename
 from propka.lib import protein_precheck
-from propka.output import write_propka
 from propka.atom import Atom
 from propka.conformation_container import ConformationContainer
 from propka.group import initialize_atom_group
@@ -41,12 +40,13 @@ def read_molecule_file(filename: str, mol_container, stream=None):
     Args:
         filename(str):  name of input file. If not using a filestream via the
             ``stream`` argument, should be a path to the file to be read.
-        mol_container:  MolecularContainer object.
+        mol_container:  :class:`~propka.molecular_container.MolecularContainer`
+            object.
         stream: optional filestream handle. If ``None``, then open
             ``filename`` as a local file for reading.
 
     Returns:
-        updated MolecularContainer object
+        updated :class:`~propka.molecular_container.MolecularContainer` object.
 
     Raises:
         ValuError if invalid input given
@@ -55,20 +55,21 @@ def read_molecule_file(filename: str, mol_container, stream=None):
         There are two main cases for using ``read_molecule_file``. The first
         (and most common) is to pass the input file (``filename``) as a
         string which gives the path of the molecule file to be read (here we
-        also pass a ``MoleculeContainer`` object named ``mol_container``).
+        also pass a :class:`~propka.molecular_container.MolecularContainer`
+        object named ``mol_container``).
 
         >>> read_molecule_file('test.pdb', mol_container)
         <propka.molecular_container.MolecularContainer at 0x7f6e0c8f2310>
 
         The other use case is when passing a file-like object, e.g. a
-        ``StringIO`` class, instance. This is done by passing the object via
-        the ``stream`` argument. Since file-like objects do not usually have
-        an associated file name, an appropirate file name should be passed to
-        the ``filename`` argument. In this case, ``filename`` is not opened for
-        reading, but instead is used to help recognise the file type (based on
-        the extension being either `.pdb` or `.propka_input`) and also uses
-        that given ``filename`` to assign a name to the input
-        MolecularContainer object.
+        :class:`io.StringIO` class, instance. This is done by passing the
+        object via the ``stream`` argument. Since file-like objects do not
+        usually have an associated file name, an appropirate file name should
+        be passed to the ``filename`` argument. In this case, ``filename`` is
+        not opened for reading, but instead is used to help recognise the file
+        type (based on the extension being either `.pdb` or `.propka_input`)
+        and also uses that given ``filename`` to assign a name to the input
+        :class:`~propka.molecular_container.MolecularContainer` object.
 
         >>> read_molecule_file('test.pdb', mol_container,
                                stream=string_io_object)

--- a/propka/run.py
+++ b/propka/run.py
@@ -80,11 +80,15 @@ def single(filename: str, optargs: list, stream=None, write_pka: bool = True):
 
     parameters = read_parameter_file(options.parameters, Parameters())
 
-    # The file we pass as `filename` is the one that is worked on, anything
-    # else in optargs will be ignored
-    options.filenames.pop(0)
-    if len(options.filenames) > 0:
-        _LOGGER.warning("Ignoring filenames: {0:s}".format(options.filenames))
+    # Only filename present should be the one passed via the arguments list
+    # Anything else will probably have been passed using optargs and the `-f`
+    # flag. Note: can be mulitple -f entries and all are appended before the
+    # input filename
+    if len(options.filenames) > 1:
+        ignored_list = options.filenames[:-1]
+        # overwrite the options.filenames entry
+        options.filenames = options.filenames[-1]
+        _LOGGER.warning(f"Ignoring filenames: {ignored_list}")
 
     my_molecule = MolecularContainer(parameters, options)
     my_molecule = read_molecule_file(filename, my_molecule, stream=stream)

--- a/propka/run.py
+++ b/propka/run.py
@@ -36,34 +36,64 @@ def main(optargs=None):
             my_molecule.write_propka()
 
 
-def single(pdbfile, optargs=None):
-    """Run a single PROPKA calculation using *pdbfile* as input.
+def single(filename: str, optargs: list, stream=None, write_pka: bool = True):
+    """Run a single PROPKA calculation using ``filename`` as input.
 
-    Commandline options can be passed as a **list** in *optargs*.
+    Args:
+        filename (str): name of input file. If filestream is not passed via
+            ``stream``, should be path to the file to be read.
+        optargs (list): Optional, commandline options for propka.
+        stream : optional filestream handle. If ``None``, then ``filename``
+            will be used as path to input file for reading.
+        write_pka (bool): Controls if the pKa file should be writen to disk.
 
-    Example
-    -------
+    Example:
     Given an input file "protein.pdb", run the equivalent of ``propka3
     --mutation=N25R/N181D -v --pH=7.2 protein.pdb`` as::
 
-       propka.run.single("protein.pdb",
-                         optargs=["--mutation=N25R/N181D", "-v", "--pH=7.2"])
+        propka.run.single("protein.pdb",
+                          optargs=["--mutation=N25R/N181D", "-v", "--pH=7.2"])
 
+    By default, a pKa file will be written. However in some cases one may wish
+    to not output this file and just have access to the
+    MolecularContainer object. If so, then pass ``False`` to ``write_pka``::
 
-    .. todo::
-       Test :func:`single`, not sure if it is correctly processing ``pdbfile``.
+        mol = propka.run.single("protein.pdb", write_pka=False)
+
+    In some cases, one may also want to pass a file-like (e.g. StringIO) object
+    instead of a file path as a string. In these cases the file-like object
+    should be passed to the ``stream`` argument. Since file-like objects do not
+    usually have names, and the ``filename`` argument must be provided to
+    help propka determine the input file type, and assigns the file name for
+    the MolecularContainer object::
+
+        mol = propka.run.single('input.pdb', stream=string_io_file)
+
+    In this case, a PDB file-like object was passed as `string_io_file`. The
+    resultant pKa file will be written out as `input.pka`.
 
     """
+    # Deal with input optarg options
     optargs = optargs if optargs is not None else []
-    options = loadOptions(*optargs)
-    pdbfile = options.filenames.pop(0)
+    optargs += [filename]
+    options = loadOptions(optargs)
+
     parameters = read_parameter_file(options.parameters, Parameters())
+
+    # The file we pass as `filename` is the one that is worked on, anything
+    # else in optargs will be ignored
+    options.filenames.pop(0)
     if len(options.filenames) > 0:
         _LOGGER.warning("Ignoring filenames: {0:s}".format(options.filenames))
+
     my_molecule = MolecularContainer(parameters, options)
-    my_molecule = read_molecule_file(pdbfile, my_molecule)
+    my_molecule = read_molecule_file(filename, my_molecule, stream=stream)
     my_molecule.calculate_pka()
-    my_molecule.write_pka()
+
+    # write outputs
     if options.generate_propka_input:
         my_molecule.write_propka()
+    if write_pka:
+        my_molecule.write_pka()
+
     return my_molecule

--- a/propka/run.py
+++ b/propka/run.py
@@ -61,12 +61,14 @@ def single(filename: str, optargs: list = None, stream=None,
 
         mol = propka.run.single("protein.pdb", write_pka=False)
 
-    In some cases, one may also want to pass a file-like (e.g. StringIO) object
+    In some cases, one may also want to pass a file-like (e.g. :class:`StringIO`) object
     instead of a file path as a string. In these cases the file-like object
-    should be passed to the ``stream`` argument. Since file-like objects do not
-    usually have names, and the ``filename`` argument must be provided to
-    help propka determine the input file type, and assigns the file name for
-    the MolecularContainer object::
+    should be passed to the ``stream`` argument and a string indicating the file type
+    in the ``filename`` argument; this string only has to look like a valid file name, it 
+    does not need to exist because the data are actually read from ``stream``. 
+    This approach is necessary because file-like objects do not usually have names, 
+    and propka uses the ``filename`` argument  to determine the 
+    input file type, and assigns the file name for the :class:`MolecularContainer` object::
 
         mol = propka.run.single('input.pdb', stream=string_io_file)
 

--- a/propka/run.py
+++ b/propka/run.py
@@ -36,7 +36,8 @@ def main(optargs=None):
             my_molecule.write_propka()
 
 
-def single(filename: str, optargs: list, stream=None, write_pka: bool = True):
+def single(filename: str, optargs: list = None, stream=None,
+           write_pka: bool = True):
     """Run a single PROPKA calculation using ``filename`` as input.
 
     Args:
@@ -74,7 +75,7 @@ def single(filename: str, optargs: list, stream=None, write_pka: bool = True):
 
     """
     # Deal with input optarg options
-    optargs = optargs if optargs is not None else []
+    optargs = list(optargs) if optargs is not None else []
     optargs += [filename]
     options = loadOptions(optargs)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -24,7 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 def test_single_file(tmpdir, pdb, options):
     """Basic regression test using propka.run.single and local file for the
     input PDB file"""
-    # Get the relevant paths
     ref_path, pdb_path = get_paths(pdb)
     filename = str(pdb_path)
 
@@ -43,7 +42,6 @@ def test_single_file(tmpdir, pdb, options):
 ])
 def test_single_filestream(tmpdir, pdb, options):
     """Basic regression test using StringIO streams for the input PDB file"""
-    # Get the relevant paths
     ref_path, pdb_path = get_paths(pdb)
     filename = f"{pdb}.pdb"
 
@@ -61,14 +59,13 @@ def test_single_nopka(tmpdir):
     """Basic test to check that the pKa file is not written when write_pka is
     `False`"""
     pdb = "1FTJ-Chain-A"
-    options = []
     ref_path, pdb_path = get_paths(pdb)
     filename = f"{pdb}.pdb"
 
     with open(pdb_path, 'r') as writer:
         filestream = StringIO(writer.read())
 
-    pkrun.single(filename, options, stream=filestream, write_pka=False)
+    pkrun.single(filename, stream=filestream, write_pka=False)
     assert not os.path.isfile(f"{pdb}.pka")
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,88 @@
+"""Tests for PROPKA's run module"""
+import logging
+import os
+from pathlib import Path
+from io import StringIO
+import pytest
+import propka.run as pkrun
+
+from .test_basic_regression import compare_output
+from .test_streamio import get_paths
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("pdb, options", [
+    pytest.param("1FTJ-Chain-A", [], id="1FTJ-Chain-A: no options"),
+    pytest.param('3SGB-subset', [
+        "--titrate_only",
+        "E:17,E:18,E:19,E:29,E:44,E:45,E:46,E:118,E:119,E:120,E:139"],
+                 id="3SGB: --titrate_only"),
+    pytest.param('1HPX-warn', ['--quiet'], id="1HPX-warn: --quiet"),
+])
+def test_single_file(tmpdir, pdb, options):
+    """Basic regression test using propka.run.single and local file for the
+    input PDB file"""
+    # Get the relevant paths
+    ref_path, pdb_path = get_paths(pdb)
+    filename = str(pdb_path)
+
+    with tmpdir.as_cwd():
+        pkrun.single(filename, options)
+        compare_output(pdb, Path.cwd(), ref_path)
+
+
+@pytest.mark.parametrize("pdb, options", [
+    pytest.param("1FTJ-Chain-A", [], id="1FTJ-Chain-A: no options"),
+    pytest.param('3SGB-subset', [
+        "--titrate_only",
+        "E:17,E:18,E:19,E:29,E:44,E:45,E:46,E:118,E:119,E:120,E:139"],
+                 id="3SGB: --titrate_only"),
+    pytest.param('1HPX-warn', ['--quiet'], id="1HPX-warn: --quiet"),
+])
+def test_single_filestream(tmpdir, pdb, options):
+    """Basic regression test using StringIO streams for the input PDB file"""
+    # Get the relevant paths
+    ref_path, pdb_path = get_paths(pdb)
+    filename = f"{pdb}.pdb"
+
+    with open(pdb_path, 'r') as writer:
+        filestream = StringIO(writer.read())
+
+    with tmpdir.as_cwd():
+        pkrun.single(filename, options, stream=filestream)
+        compare_output(pdb, Path.cwd(), ref_path)
+
+    filestream.close()
+
+
+def test_single_nopka(tmpdir):
+    """Basic test to check that the pKa file is not written when write_pka is
+    `False`"""
+    pdb = "1FTJ-Chain-A"
+    options = []
+    ref_path, pdb_path = get_paths(pdb)
+    filename = f"{pdb}.pdb"
+
+    with open(pdb_path, 'r') as writer:
+        filestream = StringIO(writer.read())
+
+    pkrun.single(filename, options, stream=filestream, write_pka=False)
+    assert not os.path.isfile(f"{pdb}.pka")
+
+
+def test_single_propka_input(tmpdir):
+    """Basic test to check that the propka_input file is written when
+    `--generate-propka-input` is passed"""
+    pdb = "1FTJ-Chain-A"
+    options = ['--generate-propka-input']
+    ref_path, pdb_path = get_paths(pdb)
+    filename = f"{pdb}.pdb"
+
+    with open(pdb_path, 'r') as writer:
+        filestream = StringIO(writer.read())
+
+    with tmpdir.as_cwd():
+        pkrun.single(filename, options, stream=filestream)
+        assert os.path.isfile(f"{pdb}.propka_input")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -14,12 +14,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("pdb, options", [
-    pytest.param("1FTJ-Chain-A", [], id="1FTJ-Chain-A: no options"),
-    pytest.param('3SGB-subset', [
+    pytest.param("1FTJ-Chain-A", (), id="1FTJ-Chain-A: no options"),
+    pytest.param('3SGB-subset', (
         "--titrate_only",
-        "E:17,E:18,E:19,E:29,E:44,E:45,E:46,E:118,E:119,E:120,E:139"],
+        "E:17,E:18,E:19,E:29,E:44,E:45,E:46,E:118,E:119,E:120,E:139"),
                  id="3SGB: --titrate_only"),
-    pytest.param('1HPX-warn', ['--quiet'], id="1HPX-warn: --quiet"),
+    pytest.param('1HPX-warn', ('--quiet',), id="1HPX-warn: --quiet"),
 ])
 def test_single_file(tmpdir, pdb, options):
     """Basic regression test using propka.run.single and local file for the
@@ -33,12 +33,12 @@ def test_single_file(tmpdir, pdb, options):
 
 
 @pytest.mark.parametrize("pdb, options", [
-    pytest.param("1FTJ-Chain-A", [], id="1FTJ-Chain-A: no options"),
-    pytest.param('3SGB-subset', [
+    pytest.param("1FTJ-Chain-A", (), id="1FTJ-Chain-A: no options"),
+    pytest.param('3SGB-subset', (
         "--titrate_only",
-        "E:17,E:18,E:19,E:29,E:44,E:45,E:46,E:118,E:119,E:120,E:139"],
+        "E:17,E:18,E:19,E:29,E:44,E:45,E:46,E:118,E:119,E:120,E:139"),
                  id="3SGB: --titrate_only"),
-    pytest.param('1HPX-warn', ['--quiet'], id="1HPX-warn: --quiet"),
+    pytest.param('1HPX-warn',('--quiet',), id="1HPX-warn: --quiet"),
 ])
 def test_single_filestream(tmpdir, pdb, options):
     """Basic regression test using StringIO streams for the input PDB file"""
@@ -73,7 +73,7 @@ def test_single_propka_input(tmpdir):
     """Basic test to check that the propka_input file is written when
     `--generate-propka-input` is passed"""
     pdb = "1FTJ-Chain-A"
-    options = ['--generate-propka-input']
+    options = ('--generate-propka-input',)
     ref_path, pdb_path = get_paths(pdb)
     filename = f"{pdb}.pdb"
 
@@ -88,14 +88,14 @@ def test_single_propka_input(tmpdir):
 def test_single_extra_files_logwarn(tmpdir, caplog):
     """Tests that a logging warning is thrown if passing files via optargs"""
     pdb = "1FTJ-Chain-A"
-    options = ['-f foo.pdb bar.pdb', '-f test.pdb test2.pdb',
-               '--generate-propka-input']
+    options = ('-f foo.pdb bar.pdb', '-f test.pdb test2.pdb',
+               '--generate-propka-input')
     ref_path, pdb_path = get_paths(pdb)
     filename = str(pdb_path)
 
     with tmpdir.as_cwd():
         pkrun.single(filename, options)
 
-        wmsg = ("Ignoring filenames: [' foo.pdb bar.pdb', "
+        wmsg = ("Ignoring extra filenames passed: [' foo.pdb bar.pdb', "
                 "' test.pdb test2.pdb']")
         assert wmsg in caplog.records[0].message

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -86,3 +86,19 @@ def test_single_propka_input(tmpdir):
     with tmpdir.as_cwd():
         pkrun.single(filename, options, stream=filestream)
         assert os.path.isfile(f"{pdb}.propka_input")
+
+
+def test_single_extra_files_logwarn(tmpdir, caplog):
+    """Tests that a logging warning is thrown if passing files via optargs"""
+    pdb = "1FTJ-Chain-A"
+    options = ['-f foo.pdb bar.pdb', '-f test.pdb test2.pdb',
+               '--generate-propka-input']
+    ref_path, pdb_path = get_paths(pdb)
+    filename = str(pdb_path)
+
+    with tmpdir.as_cwd():
+        pkrun.single(filename, options)
+
+        wmsg = ("Ignoring filenames: [' foo.pdb bar.pdb', "
+                "' test.pdb test2.pdb']")
+        assert wmsg in caplog.records[0].message


### PR DESCRIPTION
Fixes #82 

Changes:
  - input arguments now reflects the changes made to `read_molecule_file` in #84 
  - Writing of pKa file is now optional (default behaviour has been kept). This will be particularly useful downstream where we would just want to have access to the MoleculeContainer object.
  - new `test_run` file specific for testing `run`.

Notes:
  - Tests in `test_run` overlap a lot with `test_streamio`, strictly speaking I could probably ditch part of `test_streamio` as it's implicitly tested. However in some ways it might be good to have the two run in parallel to make sure that some change in run.single isn't introducing new behaviour. Either way would work, but it might not be that big a deal with the tests running as fast as they currently do?

<s>To do:
  - Add in a test for the logger warning.</s>