### PR TITLE
Fix pI reporting in last line of .pka file

### DIFF
--- a/propka/output.py
+++ b/propka/output.py
@@ -331,7 +331,7 @@ def get_charge_profile_section(protein, conformation='AVR', _=None):
     if pi_pro is None or pi_mod is None:
         str_ += "Could not determine the pI\n\n"
     else:
-        str_ += ("The pI is {0:>5.2f} (folded) and {1:>5.2f} (unfolded)\n")
+        str_ += f"The pI is {pi_pro:>5.2f} (folded) and {pi_mod:>5.2f} (unfolded)\n"
     return str_
 
 


### PR DESCRIPTION
The string was missing `.format(pi_pro, pi_mod)`.

Since Python 3.6 is the minimum supported version for propka, I opted for [f-string syntax](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep498).