### PR TITLE
propka3 --version prints version

### DIFF
--- a/docs/source/command.rst
+++ b/docs/source/command.rst
@@ -62,10 +62,9 @@ protein-ligand complexes based in the 3D structure. The
               specifying mutation labels which is used to modify
 	      <filename> according to, e.g. N25R/N181D (default: None)
 			
-.. option::  -v VERSION_LABEL, --version VERSION_LABEL
+.. option::  --version
 	     
-             specifying the sub-version of propka [Jan15/Dec19]
-	     (default: Jan15)
+	      show program's version number and exit
 	     
 .. option::  -p PARAMETERS, --parameters PARAMETERS
 	     

--- a/propka/lib.py
+++ b/propka/lib.py
@@ -198,6 +198,8 @@ def build_parser(parser=None):
        Argument `--generate-propka-input` has been removed as writing PROPKA
        input files is no longer supported.
     """
+    import propka
+
     if parser is not None:
         group = parser.add_argument_group(title="PROPKA invocation options")
     else:
@@ -241,8 +243,7 @@ def build_parser(parser=None):
         help=("specifying mutation labels which is used to modify "
               "<filename> according to, e.g. N25R/N181D"))
     group.add_argument(
-        "-v", "--version", dest="version_label", default="Jan15",
-        help="specifying the sub-version of propka [Jan15/Dec19]")
+        "--version", action="version", version=f"%(prog)s {propka.__version__}")
     group.add_argument(
         "-p", "--parameters", dest="parameters",
         default=pkg_resources.resource_filename(__name__, "propka.cfg"),


### PR DESCRIPTION
As far as I can tell, the old `--version` argument and the `version_label` option were unused ever since this repo was set up in 2012. This patch changes the `--version` argument to simply print the program version and exit.

Closes https://github.com/jensengroup/propka/issues/89