### PR TITLE
Add type annotations and mypy CI job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,3 +56,13 @@ jobs:
       with:
         name: coverage-html
         path: htmlcov/*
+
+  static_type_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.12"
+    - run: python -m pip install mypy types-setuptools
+    - run: mypy

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 docs/build
 docs/source/api/*.rst
 build/
+dist/
+.coverage

--- a/propka/atom.py
+++ b/propka/atom.py
@@ -7,9 +7,15 @@ The :class:`Atom` class contains all atom information found in the PDB file.
 """
 
 import string
+from typing import cast, List, NoReturn, Optional, TYPE_CHECKING
+
 from propka.lib import make_tidy_atom_label
 from . import hybrid36
 
+if TYPE_CHECKING:
+    from propka.group import Group
+    from propka.molecular_container import MolecularContainer
+    from propka.conformation_container import ConformationContainer
 
 # Format strings that get used in multiple places (or are very complex)
 PDB_LINE_FMT1 = (
@@ -37,37 +43,24 @@ class Atom:
        removed as reading/writing PROPKA input is no longer supported.
     """
 
-    def __init__(self, line=None):
+    def __init__(self, line: Optional[str] = None):
         """Initialize Atom object.
 
         Args:
             line:  Line from a PDB file to set properties of atom.
         """
-        self.occ = None
-        self.numb = None
-        self.res_name = None
-        self.type = None
-        self.chain_id = None
-        self.beta = None
-        self.icode = None
-        self.res_num = None
-        self.name = None
-        self.element = None
-        self.x = None
-        self.y = None
-        self.z = None
-        self.group = None
-        self.group_type = None
-        self.number_of_bonded_elements = {}
-        self.cysteine_bridge = False
-        self.bonded_atoms = []
+        self.number_of_bonded_elements: NoReturn = cast(NoReturn, {})  # FIXME unused?
+        self.group: Optional[Group] = None
+        self.group_type: Optional[str] = None
+        self.cysteine_bridge: bool = False
+        self.bonded_atoms: List[Atom] = []
         self.residue = None
-        self.conformation_container = None
-        self.molecular_container = None
+        self.conformation_container: Optional[ConformationContainer] = None
+        self.molecular_container: Optional[MolecularContainer] = None
         self.is_protonated = False
         self.steric_num_lone_pairs_set = False
-        self.terminal = None
-        self.charge = 0
+        self.terminal: Optional[str] = None
+        self.charge = 0.0
         self.charge_set = False
         self.steric_number = 0
         self.number_of_lone_pairs = 0
@@ -84,7 +77,7 @@ class Atom:
         self.sybyl_assigned = False
         self.marvin_pka = False
 
-    def set_properties(self, line):
+    def set_properties(self, line: Optional[str]):
         """Line from PDB file to set properties of atom.
 
         Args:
@@ -112,10 +105,8 @@ class Atom:
             self.z = float(line[46:54].strip())
             self.res_num = int(line[22:26].strip())
             self.res_name = "{0:<3s}".format(line[17:20].strip())
-            self.chain_id = line[21]
             # Set chain id to "_" if it is just white space.
-            if not self.chain_id.strip():
-                self.chain_id = '_'
+            self.chain_id = line[21].strip() or '_'
             self.type = line[:6].strip().lower()
 
             # TODO - define nucleic acid residue names elsewhere
@@ -134,7 +125,7 @@ class Atom:
                 self.element = '{0:1s}{1:1s}'.format(
                     self.element[0], self.element[1].lower())
 
-    def set_group_type(self, type_):
+    def set_group_type(self, type_: str):
         """Set group type of atom.
 
         Args:

--- a/propka/bonds.py
+++ b/propka/bonds.py
@@ -10,6 +10,10 @@ import math
 import json
 import pkg_resources
 import propka.calculations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from propka.molecular_container import MolecularContainer
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -329,7 +333,7 @@ class BondMaker:
                 return True
         return False
 
-    def find_bonds_for_molecules_using_boxes(self, molecules):
+    def find_bonds_for_molecules_using_boxes(self, molecules: "MolecularContainer"):
         """ Finds all bonds for a molecular container.
 
         Args:

--- a/propka/calculations.py
+++ b/propka/calculations.py
@@ -6,13 +6,17 @@ Mathematical helper functions.
 """
 
 import math
+from typing import Iterable, Optional, Tuple, TypeVar
+from .vector_algebra import _XYZ
 
+_BoundXYZ_1 = TypeVar("_BoundXYZ_1", bound=_XYZ)
+_BoundXYZ_2 = TypeVar("_BoundXYZ_2", bound=_XYZ)
 
 #: Maximum distance used to bound calculations of smallest distance
 MAX_DISTANCE = 1e6
 
 
-def squared_distance(atom1, atom2):
+def squared_distance(atom1: _XYZ, atom2: _XYZ) -> float:
     """Calculate the squared distance between two atoms.
 
     Args:
@@ -28,7 +32,7 @@ def squared_distance(atom1, atom2):
     return res
 
 
-def distance(atom1, atom2):
+def distance(atom1: _XYZ, atom2: _XYZ) -> float:
     """Calculate the distance between two atoms.
 
     Args:
@@ -40,7 +44,10 @@ def distance(atom1, atom2):
     return math.sqrt(squared_distance(atom1, atom2))
 
 
-def get_smallest_distance(atoms1, atoms2):
+def get_smallest_distance(
+    atoms1: Iterable[_BoundXYZ_1],
+    atoms2: Iterable[_BoundXYZ_2],
+) -> Tuple[Optional[_BoundXYZ_1], float, Optional[_BoundXYZ_2]]:
     """Calculate the smallest distance between two groups of atoms.
 
     Args:
@@ -59,4 +66,4 @@ def get_smallest_distance(atoms1, atoms2):
                 res_dist = dist
                 res_atom1 = atom1
                 res_atom2 = atom2
-    return [res_atom1, math.sqrt(res_dist), res_atom2]
+    return (res_atom1, math.sqrt(res_dist), res_atom2)

--- a/propka/energy.py
+++ b/propka/energy.py
@@ -7,6 +7,12 @@ Energy calculations.
 """
 import math
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from propka.conformation_container import ConformationContainer
+    from propka.group import Group
+
 from propka.calculations import squared_distance, get_smallest_distance
 
 
@@ -27,13 +33,14 @@ COMBINED_NUM_BURIED_MAX = 900
 SEPARATE_NUM_BURIED_MAX = 400
 
 
-def radial_volume_desolvation(parameters, group):
+def radial_volume_desolvation(parameters, group: "Group") -> None:
     """Calculate desolvation terms for group.
 
     Args:
         parameters:  parameters for desolvation calculation
         group:  group of atoms for calculation
     """
+    assert group.atom.conformation_container is not None
     all_atoms = group.atom.conformation_container.get_non_hydrogen_atoms()
     volume = 0.0
     group.num_volume = 0
@@ -66,7 +73,7 @@ def radial_volume_desolvation(parameters, group):
         * volume_after_allowance * scale_factor)
 
 
-def calculate_scale_factor(parameters, weight):
+def calculate_scale_factor(parameters, weight: float) -> float:
     """Calculate desolvation scaling factor.
 
     Args:
@@ -82,7 +89,7 @@ def calculate_scale_factor(parameters, weight):
     return scale_factor
 
 
-def calculate_weight(parameters, num_volume):
+def calculate_weight(parameters, num_volume: int) -> float:
     """Calculate the atom-based desolvation weight.
 
     TODO - figure out why a similar function exists in version.py
@@ -102,7 +109,7 @@ def calculate_weight(parameters, num_volume):
     return weight
 
 
-def calculate_pair_weight(parameters, num_volume1, num_volume2):
+def calculate_pair_weight(parameters, num_volume1: int, num_volume2: int) -> float:
     """Calculate the atom-pair based desolvation weight.
 
     Args:
@@ -120,7 +127,7 @@ def calculate_pair_weight(parameters, num_volume1, num_volume2):
     return weight
 
 
-def hydrogen_bond_energy(dist, dpka_max, cutoffs, f_angle=1.0):
+def hydrogen_bond_energy(dist, dpka_max: float, cutoffs, f_angle=1.0) -> float:
     """Calculate hydrogen-bond interaction pKa shift.
 
     Args:
@@ -319,7 +326,7 @@ def check_coulomb_pair(parameters, group1, group2, dist):
     return do_coulomb
 
 
-def coulomb_energy(dist, weight, parameters):
+def coulomb_energy(dist: float, weight: float, parameters) -> float:
     """Calculates the Coulomb interaction pKa shift based on Coulomb's law.
 
     Args:
@@ -340,7 +347,7 @@ def coulomb_energy(dist, weight, parameters):
     return abs(dpka)
 
 
-def backbone_reorganization(_, conformation):
+def backbone_reorganization(_, conformation: "ConformationContainer") -> None:
     """Perform calculations related to backbone reorganizations.
 
     NOTE - this was described in the code as "adding test stuff"

--- a/propka/hydrogens.py
+++ b/propka/hydrogens.py
@@ -7,15 +7,19 @@ Calculations related to hydrogen placement.
 """
 import math
 import logging
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
 from propka.protonate import Protonate
 from propka.bonds import BondMaker
 from propka.atom import Atom
 
+if TYPE_CHECKING:
+    from propka.molecular_container import MolecularContainer
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_bonding_and_protonation(molecular_container):
+def setup_bonding_and_protonation(molecular_container: "MolecularContainer") -> None:
     """Set up bonding and protonation for a molecule.
 
     Args:
@@ -34,7 +38,7 @@ def setup_bonding_and_protonation(molecular_container):
         protonator.protonate(molecular_container)
 
 
-def setup_bonding(molecular_container):
+def setup_bonding(molecular_container: "MolecularContainer") -> BondMaker:
     """Set up bonding for a molecular container.
 
     Args:
@@ -47,7 +51,7 @@ def setup_bonding(molecular_container):
     return my_bond_maker
 
 
-def setup_bonding_and_protonation_30_style(molecular_container):
+def setup_bonding_and_protonation_30_style(molecular_container: "MolecularContainer") -> BondMaker:
     """Set up bonding for a molecular container.
 
     Args:
@@ -63,7 +67,7 @@ def setup_bonding_and_protonation_30_style(molecular_container):
     return bond_maker
 
 
-def protonate_30_style(molecular_container):
+def protonate_30_style(molecular_container: "MolecularContainer") -> None:
     """Protonate the molecule.
 
     Args:
@@ -73,9 +77,9 @@ def protonate_30_style(molecular_container):
         _LOGGER.info('Now protonating %s', name)
         # split atom into residues
         curres = -1000000
-        residue = []
-        o_atom = None
-        c_atom = None
+        residue: List[Atom] = []
+        o_atom: Optional[Atom] = None
+        c_atom: Optional[Atom] = None
         for atom in molecular_container.conformations[name].atoms:
             if atom.res_num != curres:
                 curres = atom.res_num
@@ -100,7 +104,7 @@ def protonate_30_style(molecular_container):
                 residue.append(atom)
 
 
-def set_ligand_atom_names(molecular_container):
+def set_ligand_atom_names(molecular_container: "MolecularContainer") -> None:
     """Set names for ligands in molecular container.
 
     Args:
@@ -110,7 +114,7 @@ def set_ligand_atom_names(molecular_container):
         molecular_container.conformations[name].set_ligand_atom_names()
 
 
-def add_arg_hydrogen(residue):
+def add_arg_hydrogen(residue: List[Atom]) -> List[Atom]:
     """Adds Arg hydrogen atoms to residues according to the 'old way'.
 
     Args:
@@ -142,7 +146,7 @@ def add_arg_hydrogen(residue):
     return [h1_atom, h2_atom, h3_atom, h4_atom, h5_atom]
 
 
-def add_his_hydrogen(residue):
+def add_his_hydrogen(residue: List[Atom]) -> None:
     """Adds His hydrogen atoms to residues according to the 'old way'.
 
     Args:
@@ -165,7 +169,7 @@ def add_his_hydrogen(residue):
     he_atom.name = "HNE"
 
 
-def add_trp_hydrogen(residue):
+def add_trp_hydrogen(residue: List[Atom]) -> None:
     """Adds Trp hydrogen atoms to residues according to the 'old way'.
 
     Args:
@@ -188,7 +192,7 @@ def add_trp_hydrogen(residue):
     he_atom.name = "HNE"
 
 
-def add_amd_hydrogen(residue):
+def add_amd_hydrogen(residue: List[Atom]) -> None:
     """Adds Gln & Asn hydrogen atoms to residues according to the 'old way'.
 
     Args:
@@ -217,7 +221,9 @@ def add_amd_hydrogen(residue):
     h2_atom.name = "HN2"
 
 
-def add_backbone_hydrogen(residue, o_atom, c_atom):
+def add_backbone_hydrogen(residue: List[Atom],
+                          o_atom: Optional[Atom],
+                          c_atom: Optional[Atom]) -> Tuple[Optional[Atom], Optional[Atom]]:
     """Adds hydrogen backbone atoms to residues according to the old way.
 
     dR is wrong for the N-terminus (i.e. first residue) but it doesn't affect
@@ -240,18 +246,18 @@ def add_backbone_hydrogen(residue, o_atom, c_atom):
             new_c_atom = atom
         if atom.name == "O":
             new_o_atom = atom
-    if None in [c_atom, o_atom, n_atom]:
-        return [new_o_atom, new_c_atom]
+    if c_atom is None or o_atom is None or n_atom is None:
+        return (new_o_atom, new_c_atom)
     if n_atom.res_name == "PRO":
         # PRO doesn't have an H-atom; do nothing
         pass
     else:
         h_atom = protonate_direction(n_atom, o_atom, c_atom)
         h_atom.name = "H"
-    return [new_o_atom, new_c_atom]
+    return (new_o_atom, new_c_atom)
 
 
-def protonate_direction(x1_atom, x2_atom, x3_atom):
+def protonate_direction(x1_atom: Atom, x2_atom: Atom, x3_atom: Atom) -> Atom:
     """Protonates an atom, x1_atom, given a direction.
 
     New direction for x1_atom proton is (x2_atom -> x3_atom).
@@ -275,7 +281,7 @@ def protonate_direction(x1_atom, x2_atom, x3_atom):
     return h_atom
 
 
-def protonate_average_direction(x1_atom, x2_atom, x3_atom):
+def protonate_average_direction(x1_atom: Atom, x2_atom: Atom, x3_atom: Atom) -> Atom:
     """Protonates an atom, x1_atom, given a direction.
 
     New direction for x1_atom is (x1_atom/x2_atom -> x3_atom).
@@ -301,7 +307,7 @@ def protonate_average_direction(x1_atom, x2_atom, x3_atom):
     return h_atom
 
 
-def protonate_sp2(x1_atom, x2_atom, x3_atom):
+def protonate_sp2(x1_atom: Atom, x2_atom: Atom, x3_atom: Atom) -> Atom:
     """Protonates a SP2 atom, given a list of atoms
 
     Args:
@@ -323,7 +329,7 @@ def protonate_sp2(x1_atom, x2_atom, x3_atom):
     return h_atom
 
 
-def make_new_h(atom, x, y, z):
+def make_new_h(atom: Atom, x: float, y: float, z: float) -> Atom:
     """Add a new hydrogen to an atom at the specified position.
 
     Args:
@@ -347,5 +353,6 @@ def make_new_h(atom, x, y, z):
     new_h.number_of_protons_to_add = 0
     new_h.num_pi_elec_2_3_bonds = 0
     atom.bonded_atoms.append(new_h)
+    assert atom.conformation_container is not None
     atom.conformation_container.add_atom(new_h)
     return new_h

--- a/propka/vector_algebra.py
+++ b/propka/vector_algebra.py
@@ -6,16 +6,35 @@ Vector algebra for PROPKA.
 """
 import logging
 import math
+from typing import Optional, Protocol, Union
 from propka.lib import get_sorted_configurations
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
+class _XYZ(Protocol):
+    """
+    Protocol for types which have x/y/z attributes, like Vector or Atom.
+    """
+    x: float
+    y: float
+    z: float
+
+
 class Vector:
     """Vector"""
 
-    def __init__(self, xi=0.0, yi=0.0, zi=0.0, atom1=None, atom2=None):
+    x: float
+    y: float
+    z: float
+
+    def __init__(self,
+                 xi: float = 0.0,
+                 yi: float = 0.0,
+                 zi: float = 0.0,
+                 atom1: Optional[_XYZ] = None,
+                 atom2: Optional[_XYZ] = None):
         """Initialize vector.
 
         Args:
@@ -41,17 +60,17 @@ class Vector:
                 self.y = atom2.y - self.y
                 self.z = atom2.z - self.z
 
-    def __add__(self, other):
+    def __add__(self, other: _XYZ):
         return Vector(self.x + other.x,
                       self.y + other.y,
                       self.z + other.z)
 
-    def __sub__(self, other):
+    def __sub__(self, other: _XYZ):
         return Vector(self.x - other.x,
                       self.y - other.y,
                       self.z - other.z)
 
-    def __mul__(self, other):
+    def __mul__(self, other: Union["Vector", "Matrix4x4", float]):
         """Dot product, scalar and matrix multiplication."""
         if isinstance(other, Vector):
             return self.x * other.x + self.y * other.y + self.z * other.z
@@ -66,14 +85,12 @@ class Vector:
                 )
         elif type(other) in [int, float]:
             return Vector(self.x * other, self.y * other, self.z * other)
-        else:
-            _LOGGER.info('{0:s} not supported'.format(type(other)))
-            raise TypeError
+        raise TypeError(f'{type(other)} not supported')
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __pow__(self, other):
+    def __pow__(self, other: _XYZ):
         """Cross product."""
         return Vector(self.y * other.z - self.z * other.y,
                       self.z * other.x - self.x * other.z,
@@ -89,7 +106,7 @@ class Vector:
         """Return vector squared-length"""
         return self.x * self.x + self.y * self.y + self.z * self.z
 
-    def length(self):
+    def length(self) -> float:
         """Return vector length."""
         return math.sqrt(self.sq_length())
 
@@ -107,7 +124,7 @@ class Vector:
             res = Vector(self.z, 0, -self.x)
         return res
 
-    def rescale(self, new_length):
+    def rescale(self, new_length: float):
         """ Rescale vector to new length while preserving direction """
         frac = new_length/(self.length())
         res = Vector(xi=self.x*frac, yi=self.y*frac, zi=self.z*frac)
@@ -145,7 +162,7 @@ class Matrix4x4:
         self.a44 = a44i
 
 
-def angle(avec, bvec):
+def angle(avec: Vector, bvec: Vector) -> float:
     """Get the angle between two vectors.
 
     Args:
@@ -158,7 +175,7 @@ def angle(avec, bvec):
     return math.acos(dot / (avec.length() * bvec.length()))
 
 
-def angle_degrees(avec, bvec):
+def angle_degrees(avec: Vector, bvec: Vector) -> float:
     """Get the angle between two vectors in degrees.
 
     Args:
@@ -170,7 +187,7 @@ def angle_degrees(avec, bvec):
     return math.degrees(angle(avec, bvec))
 
 
-def signed_angle_around_axis(avec, bvec, axis):
+def signed_angle_around_axis(avec: Vector, bvec: Vector, axis: Vector) -> float:
     """Get signed angle of two vectors around axis in radians.
 
     Args:
@@ -189,7 +206,7 @@ def signed_angle_around_axis(avec, bvec, axis):
     return ang
 
 
-def rotate_vector_around_an_axis(theta, axis, vec):
+def rotate_vector_around_an_axis(theta: float, axis: Vector, vec: Vector) -> Vector:
     """Rotate vector around an axis.
 
     Args:
@@ -225,7 +242,7 @@ def rotate_vector_around_an_axis(theta, axis, vec):
     return vec
 
 
-def rotate_atoms_around_z_axis(theta):
+def rotate_atoms_around_z_axis(theta: float) -> Matrix4x4:
     """Get rotation matrix for z-axis.
 
     Args:
@@ -253,7 +270,7 @@ def rotate_atoms_around_z_axis(theta):
         )
 
 
-def rotate_atoms_around_y_axis(theta):
+def rotate_atoms_around_y_axis(theta: float) -> Matrix4x4:
     """Get rotation matrix for y-axis.
 
     Args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,15 @@ omit =
 exclude_lines =
     pragma: no cover
     
+[yapf]
+column_limit = 88
+based_on_style = pep8
+allow_split_before_dict_value = False
+
+[mypy]
+files = propka,tests
+exclude = (?x)(
+    /_version\.py$
+    )
+explicit_package_bases = True
+ignore_missing_imports = True

--- a/tests/test_basic_regression.py
+++ b/tests/test_basic_regression.py
@@ -10,6 +10,7 @@ from propka.parameters import Parameters
 from propka.molecular_container import MolecularContainer
 from propka.input import read_parameter_file, read_molecule_file
 from propka.lib import loadOptions
+from typing import List
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,8 +33,6 @@ RESULTS_DIR = Path("tests/results")
 if not RESULTS_DIR.is_dir():
     _LOGGER.warning("Switching to sub-directory")
     RESULTS_DIR = Path("results")
-# Arguments to add to all tests
-DEFAULT_ARGS = []
 
 
 def get_test_dirs():
@@ -87,8 +86,8 @@ def run_propka(options, pdb_path, tmp_path):
 def parse_pka(pka_path: Path) -> dict:
     """Parse testable data from a .pka file into a dictionary.
     """
-    pka_list = []
-    data = {"pKa": pka_list}
+    pka_list: List[float] = []
+    data: dict = {"pKa": pka_list}
 
     with open(pka_path, "rt") as pka_file:
         at_pka = False
@@ -98,6 +97,7 @@ def parse_pka(pka_path: Path) -> dict:
                     at_pka = False
                 else:
                     m = re.search(r'\d+\.\d+', line[13:])
+                    assert m is not None
                     pka_list.append(float(m.group()))
             elif "model-pKa" in line:
                 at_pka = True


### PR DESCRIPTION
Static type checking is becoming popular for serious Python projects. This PR adds a substantial amount of type annotations and a static type checking CI job with [mypy](https://github.com/python/mypy).

Static type checking reveals lots of potential for cleanup and better design decisions, but this patch deliberately doesn't clean up anything. Cleanup could happen in follow-ups.