### PR TITLE
Refactor deprecated pkg_resources usage

### DIFF
--- a/propka/bonds.py
+++ b/propka/bonds.py
@@ -8,7 +8,7 @@ PROPKA representation of bonds.
 import logging
 import math
 import json
-import pkg_resources
+from pathlib import Path
 import propka.calculations
 from typing import TYPE_CHECKING
 
@@ -35,6 +35,8 @@ class BondMaker:
     TODO - the documentation for this class needs to be improved.
     """
     def __init__(self):
+        from propka.input import open_file_for_reading
+
         # predefined bonding distances
         self.distances = {'S-S': DISULFIDE_DISTANCE,
                           'F-F': FLUORIDE_DISTANCE}
@@ -51,9 +53,8 @@ class BondMaker:
             + [self.default_dist_squared])
         self.max_sq_distance = max(distances)
         # protein bonding data
-        self.data_file_name = (
-            pkg_resources.resource_filename(__name__, 'protein_bonds.json'))
-        with open(self.data_file_name, 'rt') as json_file:
+        self.data_file_name = Path(__file__).parent / 'protein_bonds.json'
+        with open_file_for_reading(self.data_file_name) as json_file:
             self.protein_bonds = json.load(json_file)
         self.intra_residue_backbone_bonds = {'N': ['CA'], 'CA': ['N', 'C'],
                                              'C': ['CA', 'O'], 'O': ['C']}

--- a/propka/lib.py
+++ b/propka/lib.py
@@ -8,7 +8,7 @@ Implements many of the main functions used to call PROPKA.
 import sys
 import logging
 import argparse
-import pkg_resources
+from pathlib import Path
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -246,7 +246,7 @@ def build_parser(parser=None):
         "--version", action="version", version=f"%(prog)s {propka.__version__}")
     group.add_argument(
         "-p", "--parameters", dest="parameters",
-        default=pkg_resources.resource_filename(__name__, "propka.cfg"),
+        default=str(Path(__file__).parent / "propka.cfg"),
         help="set the parameter file [{default:s}]")
     try:
         group.add_argument(

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,29 @@
+import propka.input as m
+import zipfile
+
+
+def test_open_file_for_reading(tmp_path):
+    path = tmp_path / "tmp.txt"
+    path.write_text("One\nTwo\nThree\n")
+    # str
+    with m.open_file_for_reading(str(path)) as outer:
+        assert outer.read() == "One\nTwo\nThree\n"
+    assert outer.closed
+    # Path
+    with m.open_file_for_reading(path) as outer:
+        # TextIO
+        with m.open_file_for_reading(outer) as inner:
+            assert inner.readline() == "One\n"
+        assert not outer.closed
+        assert outer.readline() == "Two\n"
+    assert outer.closed
+
+
+def test_open_file_for_reading__zipfile(tmp_path):
+    zippath = tmp_path / "tmp.zip"
+    arcname = "foo/bar.txt"
+    with zipfile.ZipFile(zippath, "w") as ziphandle:
+        ziphandle.writestr(arcname, "One\nTwo\nThree\n")
+    with m.open_file_for_reading(zippath / arcname) as outer:
+        assert outer.readline() == "One\n"
+    assert outer.closed


### PR DESCRIPTION
- Remove deprecated [pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html) usage
- Locate resources relative to `__file__`
- Support egg/zip with `open_file_for_reading`