### PR TITLE
chore: Drop Python <=3.9, upgrade workflow extensions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,12 +51,12 @@ jobs:
     - name: Store coverage text results
       uses: actions/upload-artifact@v6
       with:
-        name: coverage-text
+        name: coverage-text-${{ matrix.python-version }}
         path: coverage.txt
     - name: Store coverage HTML results
       uses: actions/upload-artifact@v6
       with:
-        name: coverage-html
+        name: coverage-html-${{ matrix.python-version }}
         path: htmlcov/*
 
   static_type_check:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -49,12 +49,12 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash)
       if: ${{ ! startsWith(matrix.os, 'windows') }}
     - name: Store coverage text results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-text
         path: coverage.txt
     - name: Store coverage HTML results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-html
         path: htmlcov/*
@@ -62,8 +62,8 @@ jobs:
   static_type_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - run: python -m pip install mypy types-setuptools

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,12 +51,12 @@ jobs:
     - name: Store coverage text results
       uses: actions/upload-artifact@v6
       with:
-        name: coverage-text-${{ matrix.python-version }}
+        name: coverage-text-${{ matrix.os }}-py${{ matrix.python-version }}
         path: coverage.txt
     - name: Store coverage HTML results
       uses: actions/upload-artifact@v6
       with:
-        name: coverage-html-${{ matrix.python-version }}
+        name: coverage-html-${{ matrix.os }}-py${{ matrix.python-version }}
         path: htmlcov/*
 
   static_type_check:

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ See http://propka.org/ for the PROPKA web server.
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -58,7 +56,7 @@ See http://propka.org/ for the PROPKA web server.
     package_data={'propka': ['*.dat', '*.cfg', '*.json']},
     entry_points={'console_scripts': ['propka3 = propka.run:main', ]},
     zip_safe=True,
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     tests_require=["numpy", "pytest"],
     test_suite="tests",
     )


### PR DESCRIPTION
- Drop Python 3.8 and 3.9
- Upgrade github actions workflow extensions
- Use unique artifact names per workflow run

See https://github.com/jensengroup/propka/pull/199#issuecomment-3797014026