### PR TITLE
Handle degenerate ligand planarity geometry

### DIFF
--- a/propka/ligand.py
+++ b/propka/ligand.py
@@ -319,10 +319,16 @@ def are_atoms_planar(atoms):
         return False
     vec1 = Vector(atom1=atoms[0], atom2=atoms[1])
     vec2 = Vector(atom1=atoms[0], atom2=atoms[2])
-    norm = vec1.cross(vec2).rescale(1.0)
+    norm = vec1.cross(vec2)
+    if norm.sq_length() == 0.0:
+        return False
+    norm = norm.rescale(1.0)
     margin = PLANARITY_MARGIN
     for atom in atoms[3:]:
-        vec = Vector(atom1=atoms[0], atom2=atom).rescale(1.0)
+        vec = Vector(atom1=atoms[0], atom2=atom)
+        if vec.sq_length() == 0.0:
+            return False
+        vec = vec.rescale(1.0)
         if abs(vec.dot(norm)) > margin:
             return False
     return True

--- a/tests/test_ligand.py
+++ b/tests/test_ligand.py
@@ -1,0 +1,26 @@
+"""Tests for ligand geometry helpers."""
+
+from propka.ligand import are_atoms_planar
+from propka.vector_algebra import Vector
+
+
+def test_are_atoms_planar_with_degenerate_normal():
+    atoms = [
+        Vector(0.0, 0.0, 0.0),
+        Vector(1.0, 0.0, 0.0),
+        Vector(1.0, 0.0, 0.0),
+        Vector(0.0, 1.0, 0.0),
+    ]
+
+    assert are_atoms_planar(atoms) is False
+
+
+def test_are_atoms_planar_with_duplicate_test_atom():
+    atoms = [
+        Vector(0.0, 0.0, 0.0),
+        Vector(1.0, 0.0, 0.0),
+        Vector(0.0, 1.0, 0.0),
+        Vector(0.0, 0.0, 0.0),
+    ]
+
+    assert are_atoms_planar(atoms) is False


### PR DESCRIPTION
Fixes #216.

## Summary

`are_atoms_planar()` currently assumes that every vector it normalizes has nonzero length. Duplicate or collinear coordinates can therefore raise `ZeroDivisionError` instead of producing a planarity result.

This patch conservatively treats geometry that cannot define a unique plane as non-planar:

- return `False` when the first two displacement vectors have a zero-length cross product;
- return `False` when a later atom has zero displacement from the anchor atom.

Valid, non-degenerate geometry follows the existing calculation unchanged.

## Tests

Two focused regression tests cover both normalization sites. Local validation:

```text
pytest tests/test_ligand.py -q
2 passed

pytest -q
63 passed

mypy
Success: no issues found in 37 source files

flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
0
```

On the real RCSB 8EL4 PDB and mmCIF inputs, both formats reach the new guard with the same degenerate coordinates and return `False`:

```text
[(-26.518, -7.369, 46.419),
 (-25.607, -7.208, 47.534),
 (-26.518, -7.369, 46.419)]
```

Before this patch, both inputs fail at that point with `ZeroDivisionError`.

## Scope

After this exception is handled, 8EL4 exposes a separate performance problem later in bonding/ligand preparation, related to its overlapping whole-chain alternate conformations. This PR deliberately does not change conformation top-up or bonding behavior; it only makes the planarity helper safe for degenerate inputs.
